### PR TITLE
Prompt recalculation of node heights when loading local data files

### DIFF
--- a/ui/src/main/java/dk/itu/ui/FloodingApp.java
+++ b/ui/src/main/java/dk/itu/ui/FloodingApp.java
@@ -48,7 +48,7 @@ public class FloodingApp extends GameApplication {
         Services.withServices(services -> {
 
             // Temporary whilst using in-memory
-            services.getOsmService(state.isWithDb()).loadOsmData("bornholm.osm");
+            services.getOsmService(state.isWithDb()).loadOsmData("tuna.osm");
 
             state.resetWindowBounds();
             state.updateMinMaxWaterLevels(services);

--- a/ui/src/main/java/dk/itu/ui/components/DataLoadComponent.java
+++ b/ui/src/main/java/dk/itu/ui/components/DataLoadComponent.java
@@ -36,6 +36,7 @@ public class DataLoadComponent extends SplitMenuButton {
                     services.getHeightCurveService().loadGmlFileData(selectedFile);
                     setDisable(false);
                     setText(selectedFile);
+                    state.recalculateNodeHeight();
                 }
             });
         });


### PR DESCRIPTION
We never added the recalculation of node heights in the final cleanup before exam.